### PR TITLE
Add "type_name" support in emulate_intrinsic()

### DIFF
--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -78,6 +78,13 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
                 let id_val = Scalar::from_uint(type_id, dest.layout.size);
                 self.write_scalar(id_val, dest)?;
             }
+            
+            "type_name" => {
+                let ty = substs.type_at(0);
+                let ty_name = ty.to_string();
+                let value = self.str_to_immediate(&ty_name)?;
+                self.write_immediate(value, dest)?;
+            }            
             | "ctpop"
             | "cttz"
             | "cttz_nonzero"


### PR DESCRIPTION
It was suggested by /u/YatoRust on Reddit that I open a PR for this, so I am.